### PR TITLE
Create static WhatsApp chat analytics dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,0 +1,39 @@
+# WhatsApp Chat Insights Dashboard
+
+A fully client-side dashboard for exploring WhatsApp chat exports. Upload a `.zip` or `.txt` export and instantly explore engagement metrics, timelines, key words, and emoji usage. Generate a Markdown summary for retrospectives or knowledge bases — all without leaving your browser.
+
+## Features
+
+- 📦 **Drag-and-drop uploads** for standard WhatsApp exports (zip or raw text).
+- 📊 **Interactive analytics** including participant activity, hourly rhythm, and quick insights.
+- 🧠 **Smart text processing** for word frequencies, emoji counts, and streak detection.
+- 🗓️ **Date filtering** to focus on specific time windows.
+- 📝 **Markdown export** builder with configurable title and sample message count.
+- 🔒 **Privacy-first** — processing happens locally in the browser, perfect for GitHub Pages hosting.
+
+## Getting started locally
+
+1. Install dependencies for the lightweight test harness:
+
+   ```bash
+   npm install
+   ```
+
+2. Run the parser regression test against the bundled example chat export:
+
+   ```bash
+   npm test
+   ```
+
+3. Open `index.html` directly in your browser (or via a simple static server) to try the dashboard.
+
+## Deploying to GitHub Pages
+
+The app is a static site. Commit the repository to GitHub and enable GitHub Pages (e.g., from the `main` branch or the `docs/` folder if you prefer). No build step or server runtime is required.
+
+## Credits
+
+- [Chart.js](https://www.chartjs.org/) powers the visualisations.
+- [JSZip](https://stuk.github.io/jszip/) is used client-side to unpack WhatsApp archives.
+
+Enjoy the insights! ✨

--- a/index.html
+++ b/index.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>WhatsApp Chat Insights Dashboard</title>
+  <link rel="stylesheet" href="styles.css" />
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.6/dist/chart.umd.min.js" defer></script>
+  <script src="https://cdn.jsdelivr.net/npm/jszip@3.10.1/dist/jszip.min.js" defer></script>
+  <script type="module" src="js/app.js" defer></script>
+</head>
+<body>
+  <header class="app-header">
+    <div class="branding">
+      <h1>WhatsApp Chat Insights Dashboard</h1>
+      <p>Upload your exported WhatsApp chat (.zip or .txt) to explore rich analytics and craft shareable summaries.</p>
+    </div>
+  </header>
+
+  <main class="app-main">
+    <section class="card upload-card" aria-labelledby="upload-title">
+      <div class="upload-header">
+        <h2 id="upload-title">Start with your chat export</h2>
+        <p>Select the exported <strong>.zip</strong> file from WhatsApp, or a plain text chat file.</p>
+      </div>
+      <label class="file-input" for="chat-file">
+        <input type="file" id="chat-file" accept=".zip,.txt" />
+        <span>Click to choose a file or drag it here</span>
+      </label>
+      <p class="helper-text" id="file-helper">No file selected.</p>
+      <div class="status" id="load-status" role="status" aria-live="polite"></div>
+    </section>
+
+    <section class="card controls-card" aria-labelledby="filters-title">
+      <div class="controls-header">
+        <h2 id="filters-title">Filter &amp; focus</h2>
+        <p>Choose a time window to drill into specific periods of the conversation.</p>
+      </div>
+      <div class="controls-grid">
+        <label>
+          <span>Start date</span>
+          <input type="date" id="start-date" disabled />
+        </label>
+        <label>
+          <span>End date</span>
+          <input type="date" id="end-date" disabled />
+        </label>
+        <button id="apply-range" disabled>Apply date range</button>
+        <button id="reset-range" disabled class="subtle">Reset</button>
+      </div>
+    </section>
+
+    <section class="card stats-card" aria-labelledby="stats-title">
+      <div class="section-header">
+        <h2 id="stats-title">Conversation snapshot</h2>
+        <p>High-level metrics update instantly as you adjust filters.</p>
+      </div>
+      <div class="stats-grid" id="summary-cards"></div>
+    </section>
+
+    <section class="card charts-card" aria-labelledby="charts-title">
+      <div class="section-header">
+        <h2 id="charts-title">Activity highlights</h2>
+        <p>Compare participation and see when the conversation is most active.</p>
+      </div>
+      <div class="charts-grid">
+        <div class="chart-block">
+          <h3>Messages per participant</h3>
+          <canvas id="participants-chart" aria-label="Messages per participant chart" role="img"></canvas>
+        </div>
+        <div class="chart-block">
+          <h3>Hourly rhythm</h3>
+          <canvas id="hourly-chart" aria-label="Messages by hour chart" role="img"></canvas>
+        </div>
+      </div>
+    </section>
+
+    <section class="card insights-card" aria-labelledby="insights-title">
+      <div class="section-header">
+        <h2 id="insights-title">Deeper insights</h2>
+        <p>Discover themes, emojis, and streaks that make this chat unique.</p>
+      </div>
+      <div class="insights-grid">
+        <div>
+          <h3>Top words</h3>
+          <ol id="top-words" class="pill-list"></ol>
+        </div>
+        <div>
+          <h3>Top emojis</h3>
+          <ol id="top-emojis" class="pill-list"></ol>
+        </div>
+        <div>
+          <h3>Noteworthy observations</h3>
+          <ul id="insight-list" class="insight-list"></ul>
+        </div>
+      </div>
+    </section>
+
+    <section class="card export-card" aria-labelledby="export-title">
+      <div class="section-header">
+        <h2 id="export-title">Export a Markdown recap</h2>
+        <p>Generate a polished summary for wikis, retros, or changelog entries.</p>
+      </div>
+      <div class="export-controls">
+        <label>
+          <span>Summary title</span>
+          <input type="text" id="md-title" placeholder="e.g. Sprint Retro – Team Chat Highlights" />
+        </label>
+        <label>
+          <span>Include sample messages</span>
+          <input type="number" id="sample-count" min="0" max="10" value="3" />
+        </label>
+        <button id="generate-md" disabled>Download Markdown</button>
+      </div>
+      <textarea id="md-preview" aria-label="Markdown preview" readonly placeholder="Markdown summary will appear here after generation."></textarea>
+    </section>
+  </main>
+
+  <footer class="app-footer">
+    <p>Built for GitHub Pages · All processing happens in your browser · No data ever leaves your device.</p>
+  </footer>
+</body>
+</html>

--- a/js/app.js
+++ b/js/app.js
@@ -1,0 +1,360 @@
+import {
+  parseChat,
+  computeStatistics,
+  filterMessagesByDate,
+  generateMarkdownSummary
+} from './chatParser.js';
+
+let allMessages = [];
+let filteredMessages = [];
+let stats = null;
+let fullStats = null;
+let participantsChart = null;
+let hourlyChart = null;
+
+const fileInput = document.getElementById('chat-file');
+const fileHelper = document.getElementById('file-helper');
+const loadStatus = document.getElementById('load-status');
+const startDateInput = document.getElementById('start-date');
+const endDateInput = document.getElementById('end-date');
+const applyRangeButton = document.getElementById('apply-range');
+const resetRangeButton = document.getElementById('reset-range');
+const summaryCardsContainer = document.getElementById('summary-cards');
+const topWordsList = document.getElementById('top-words');
+const topEmojisList = document.getElementById('top-emojis');
+const insightList = document.getElementById('insight-list');
+const mdTitleInput = document.getElementById('md-title');
+const sampleCountInput = document.getElementById('sample-count');
+const generateMdButton = document.getElementById('generate-md');
+const mdPreview = document.getElementById('md-preview');
+
+async function loadChatFile(file) {
+  if (!file) return null;
+
+  if (file.name.toLowerCase().endsWith('.zip')) {
+    const arrayBuffer = await file.arrayBuffer();
+    const zip = await JSZip.loadAsync(arrayBuffer);
+    const txtFileName = Object.keys(zip.files).find((name) => name.endsWith('.txt'));
+    if (!txtFileName) {
+      throw new Error('No .txt file found inside the zip archive.');
+    }
+    return zip.files[txtFileName].async('string');
+  }
+
+  return file.text();
+}
+
+function formatDateForInput(date) {
+  if (!date) return '';
+  return date.toISOString().slice(0, 10);
+}
+
+function formatDateFriendly(date) {
+  if (!date) return '—';
+  return new Intl.DateTimeFormat(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric'
+  }).format(date);
+}
+
+function updateSummaryCards(currentStats) {
+  const cards = [
+    {
+      title: 'Messages',
+      value: currentStats.totalMessages.toLocaleString(),
+      hint: 'Includes only participant messages.'
+    },
+    {
+      title: 'Participants',
+      value: currentStats.participants.length,
+      hint: 'Unique senders detected.'
+    },
+    {
+      title: 'Total words',
+      value: currentStats.totalWords.toLocaleString(),
+      hint: 'Excludes attachments and system notifications.'
+    },
+    {
+      title: 'Media shared',
+      value: currentStats.mediaCount.toLocaleString(),
+      hint: 'Messages detected as photos, videos, voice notes, etc.'
+    },
+    {
+      title: 'First message',
+      value: formatDateFriendly(currentStats.firstMessageDate),
+      hint: 'Within the selected range.'
+    },
+    {
+      title: 'Last message',
+      value: formatDateFriendly(currentStats.lastMessageDate),
+      hint: 'Within the selected range.'
+    }
+  ];
+
+  summaryCardsContainer.innerHTML = cards
+    .map((card) => `
+      <article class="stat-card">
+        <h3>${card.title}</h3>
+        <p>${card.value}</p>
+        <span>${card.hint}</span>
+      </article>
+    `)
+    .join('');
+}
+
+function renderChart({ elementId, labels, data, label, color, chartRef }) {
+  const ctx = document.getElementById(elementId);
+  if (!ctx) return null;
+
+  if (chartRef) {
+    chartRef.destroy();
+  }
+
+  return new Chart(ctx, {
+    type: 'bar',
+    data: {
+      labels,
+      datasets: [
+        {
+          label,
+          data,
+          backgroundColor: color,
+          borderRadius: 8
+        }
+      ]
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      scales: {
+        x: {
+          ticks: {
+            color: '#cbd5f5',
+            maxRotation: 45,
+            minRotation: 0,
+            autoSkip: labels.length > 12
+          },
+          grid: {
+            color: 'rgba(148, 163, 184, 0.1)'
+          }
+        },
+        y: {
+          ticks: {
+            color: '#cbd5f5'
+          },
+          grid: {
+            color: 'rgba(148, 163, 184, 0.1)'
+          }
+        }
+      },
+      plugins: {
+        legend: {
+          display: false
+        }
+      }
+    }
+  });
+}
+
+function updateCharts(currentStats) {
+  const participantLabels = currentStats.participants;
+  const participantData = participantLabels.map((participant) => currentStats.messageCountByParticipant[participant]);
+
+  participantsChart = renderChart({
+    elementId: 'participants-chart',
+    labels: participantLabels,
+    data: participantData,
+    label: 'Messages',
+    color: 'rgba(56, 189, 248, 0.65)',
+    chartRef: participantsChart
+  });
+
+  const hourlyLabels = Array.from({ length: 24 }, (_, i) => `${i.toString().padStart(2, '0')}:00`);
+  const hourlyData = currentStats.messagesByHour;
+
+  hourlyChart = renderChart({
+    elementId: 'hourly-chart',
+    labels: hourlyLabels,
+    data: hourlyData,
+    label: 'Messages per hour',
+    color: 'rgba(129, 140, 248, 0.65)',
+    chartRef: hourlyChart
+  });
+}
+
+function updateTopList(container, items, formatter) {
+  if (!items.length) {
+    container.innerHTML = '<li>No data yet</li>';
+    return;
+  }
+
+  container.innerHTML = items
+    .map((item) => `<li>${formatter(item)}</li>`)
+    .join('');
+}
+
+function buildInsights(currentStats) {
+  const insights = [];
+  if (currentStats.busiestDay) {
+    insights.push(`Most active day: <strong>${currentStats.busiestDay.date}</strong> with ${currentStats.busiestDay.count} messages.`);
+  }
+  if (currentStats.busiestHour !== null) {
+    insights.push(`Peak hour: <strong>${currentStats.busiestHour}:00</strong> (UTC) when the chat is most lively.`);
+  }
+  if (currentStats.longestStreak > 1 && currentStats.longestStreakRange) {
+    insights.push(`Longest daily streak: <strong>${currentStats.longestStreak} days</strong> from ${currentStats.longestStreakRange.start} to ${currentStats.longestStreakRange.end}.`);
+  }
+    if (Object.keys(currentStats.responseTimes).length) {
+      const fastest = Object.entries(currentStats.responseTimes).sort((a, b) => a[1] - b[1])[0];
+      if (fastest) {
+        insights.push(`Quickest responder: <strong>${fastest[0]}</strong> with an average reply around ${fastest[1]} minutes.`);
+      }
+    }
+  if (!insights.length) {
+    insights.push('Insights will appear here once you load a chat.');
+  }
+
+  insightList.innerHTML = insights.map((item) => `<li>${item}</li>`).join('');
+}
+
+function enableControls(enabled) {
+  [startDateInput, endDateInput, applyRangeButton, resetRangeButton, generateMdButton].forEach((el) => {
+    el.disabled = !enabled;
+  });
+}
+
+function applyFilters() {
+  const start = startDateInput.value || null;
+  const end = endDateInput.value || null;
+
+  filteredMessages = filterMessagesByDate(allMessages, start, end);
+  stats = computeStatistics(filteredMessages);
+  updateSummaryCards(stats);
+  updateCharts(stats);
+
+  updateTopList(topWordsList, stats.topWords, ([word, count]) => `<span>${word}</span><span>${count}</span>`);
+  updateTopList(topEmojisList, stats.topEmojis, ([emoji, count]) => `<span>${emoji}</span><span>${count}</span>`);
+  buildInsights(stats);
+}
+
+function resetFilters() {
+  if (!fullStats) return;
+  startDateInput.value = formatDateForInput(fullStats.firstMessageDate);
+  endDateInput.value = formatDateForInput(fullStats.lastMessageDate);
+  filteredMessages = [...allMessages];
+  stats = computeStatistics(filteredMessages);
+  updateSummaryCards(stats);
+  updateCharts(stats);
+  updateTopList(topWordsList, stats.topWords, ([word, count]) => `<span>${word}</span><span>${count}</span>`);
+  updateTopList(topEmojisList, stats.topEmojis, ([emoji, count]) => `<span>${emoji}</span><span>${count}</span>`);
+  buildInsights(stats);
+}
+
+function showError(message) {
+  loadStatus.textContent = message;
+  loadStatus.classList.add('error');
+}
+
+function clearStatus() {
+  loadStatus.textContent = '';
+  loadStatus.classList.remove('error');
+}
+
+function prepareMarkdown() {
+  if (!stats) return;
+  const sampleCount = Math.max(0, Math.min(10, Number(sampleCountInput.value) || 0));
+  const markdown = generateMarkdownSummary({
+    title: mdTitleInput.value.trim() || 'WhatsApp Chat Summary',
+    messages: filteredMessages,
+    stats,
+    startDate: startDateInput.value || undefined,
+    endDate: endDateInput.value || undefined,
+    sampleCount
+  });
+
+  mdPreview.value = markdown;
+
+  const blob = new Blob([markdown], { type: 'text/markdown' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = `${(mdTitleInput.value || 'whatsapp-chat-summary').toLowerCase().replace(/[^a-z0-9]+/g, '-')}.md`;
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  setTimeout(() => URL.revokeObjectURL(url), 5000);
+}
+
+fileInput.addEventListener('change', async (event) => {
+  const [file] = event.target.files;
+  if (!file) return;
+
+  fileHelper.textContent = file.name;
+  loadStatus.textContent = 'Parsing chat…';
+  clearStatus();
+
+  try {
+    const rawText = await loadChatFile(file);
+    allMessages = parseChat(rawText);
+
+    if (!allMessages.length) {
+      throw new Error('No messages could be parsed. Please ensure this is a standard WhatsApp export.');
+    }
+
+    fullStats = computeStatistics(allMessages);
+    stats = fullStats;
+    filteredMessages = [...allMessages];
+
+    const firstDate = formatDateForInput(fullStats.firstMessageDate);
+    const lastDate = formatDateForInput(fullStats.lastMessageDate);
+
+    startDateInput.value = firstDate;
+    startDateInput.min = firstDate;
+    startDateInput.max = lastDate;
+    endDateInput.value = lastDate;
+    endDateInput.min = firstDate;
+    endDateInput.max = lastDate;
+
+    enableControls(true);
+    applyFilters();
+
+    loadStatus.textContent = `Loaded ${stats.totalMessages.toLocaleString()} messages from ${stats.participants.length} participants.`;
+  } catch (error) {
+    console.error(error);
+    showError(error.message || 'Something went wrong while parsing the chat.');
+    enableControls(false);
+  }
+});
+
+applyRangeButton.addEventListener('click', () => {
+  applyFilters();
+  loadStatus.textContent = 'Filters applied.';
+});
+
+resetRangeButton.addEventListener('click', () => {
+  resetFilters();
+  loadStatus.textContent = 'Filters reset to full range.';
+});
+
+generateMdButton.addEventListener('click', () => {
+  prepareMarkdown();
+  loadStatus.textContent = 'Markdown summary generated!';
+});
+
+document.addEventListener('dragover', (event) => {
+  if (event.target === fileInput || fileInput.contains(event.target)) return;
+  event.preventDefault();
+});
+
+document.addEventListener('drop', async (event) => {
+  if (!event.dataTransfer?.files?.length) return;
+  event.preventDefault();
+  fileInput.files = event.dataTransfer.files;
+  fileInput.dispatchEvent(new Event('change'));
+});
+
+window.addEventListener('DOMContentLoaded', () => {
+  enableControls(false);
+  mdPreview.value = '';
+});

--- a/js/chatParser.js
+++ b/js/chatParser.js
@@ -1,0 +1,444 @@
+const headerPatterns = [
+  {
+    regex: /^\[(\d{1,2})\/(\d{1,2})\/(\d{2,4}),\s([^\]]+)\]\s(.+)$/
+  },
+  {
+    regex: /^(\d{1,2})\/(\d{1,2})\/(\d{2,4}),\s(\d{1,2}:\d{2}(?::\d{2})?(?:\s?[AP]M)?)\s-\s(.+)$/
+  }
+];
+
+const stopWords = new Set([
+  'the','and','you','for','that','with','this','have','but','not','are','your','was','get','got','just','they','them','what','when','from','there','their','would','could','about','will','cant','dont','didnt','im','its','were','had','has','how','all','out','now','like','yeah','yes','she','his','her','who','him','our','one','why','too','wasnt','havent','into','then','than','ill','ive','did','okay','ok','sure','well','also','more','some','been','over','here','back','much','make','really','know','going','want','time','see','let','say','good','thanks','thank','thats','doesnt','aint','u','ur','lol','omg','lmfao','lmao','haha','hahaha','http','https','to','is','in','on','at','we','me','my','do','if','as','be','an','or','by','no','up','so','it','he','ya','oh','hadnt','should','ive','theyll','theyd','theirs','ours','mine','of','can'
+]);
+
+function matchMessageHeader(line) {
+  for (const { regex } of headerPatterns) {
+    const match = line.match(regex);
+    if (match) {
+      return {
+        day: match[1],
+        month: match[2],
+        year: match[3],
+        time: match[4].replace(/[\u202f\u00a0]/g, ' ').trim(),
+        rest: match[5]
+      };
+    }
+  }
+  return null;
+}
+
+function determineDateFormat(lines) {
+  for (const line of lines) {
+    const header = matchMessageHeader(line);
+    if (header) {
+      const first = parseInt(header.day, 10);
+      const second = parseInt(header.month, 10);
+      if (first > 12) return 'DMY';
+      if (second > 12) return 'MDY';
+    }
+  }
+  return 'DMY';
+}
+
+function parseDate(day, month, year, timeStr, format) {
+  let d = parseInt(day, 10);
+  let m = parseInt(month, 10);
+  let y = parseInt(year, 10);
+
+  if (format === 'MDY') {
+    [d, m] = [m, d];
+  }
+
+  if (y < 100) {
+    y += y >= 70 ? 1900 : 2000;
+  }
+
+  let hours = 0;
+  let minutes = 0;
+  let seconds = 0;
+  let period = null;
+  const timeMatch = timeStr.match(/^(\d{1,2}):(\d{2})(?::(\d{2}))?(?:\s?([AP]M))?$/i);
+  if (timeMatch) {
+    hours = parseInt(timeMatch[1], 10);
+    minutes = parseInt(timeMatch[2], 10);
+    seconds = timeMatch[3] ? parseInt(timeMatch[3], 10) : 0;
+    period = timeMatch[4];
+  }
+
+  if (period) {
+    const upper = period.toUpperCase();
+    if (upper === 'PM' && hours < 12) {
+      hours += 12;
+    }
+    if (upper === 'AM' && hours === 12) {
+      hours = 0;
+    }
+  }
+
+  return new Date(Date.UTC(y, m - 1, d, hours, minutes, seconds));
+}
+
+function normaliseAuthor(author) {
+  if (!author) return 'System';
+  return author.replace(/^"|"$/g, '').trim();
+}
+
+export function parseChat(rawText) {
+  if (!rawText) return [];
+  const text = rawText.replace(/\uFEFF/g, '');
+  const lines = text.split(/\r?\n/);
+  const format = determineDateFormat(lines);
+
+  const messages = [];
+  let current = null;
+
+  for (const line of lines) {
+    const header = matchMessageHeader(line);
+    if (header) {
+      if (current) {
+        current.content = current.content.trim();
+        messages.push(current);
+      }
+      const timestamp = parseDate(header.day, header.month, header.year, header.time, format);
+      const authorSplit = header.rest.split(/:\s/);
+      if (authorSplit.length >= 2) {
+        const author = normaliseAuthor(authorSplit.shift());
+        const content = authorSplit.join(': ').trim();
+        current = {
+          timestamp,
+          author,
+          content,
+          type: 'message'
+        };
+      } else {
+        current = {
+          timestamp,
+          author: 'System',
+          content: header.rest.trim(),
+          type: 'system'
+        };
+      }
+    } else if (current) {
+      current.content += `\n${line}`;
+    }
+  }
+
+  if (current) {
+    current.content = current.content.trim();
+    messages.push(current);
+  }
+
+  return messages.filter((msg) => !Number.isNaN(msg.timestamp.getTime()));
+}
+
+function isMediaMessage(content) {
+  if (!content) return false;
+  const lc = content.toLowerCase();
+  return lc.includes('omitted') || lc.includes('<media') || lc.includes('image omitted') || lc.includes('video omitted');
+}
+
+function extractWords(content) {
+  return content
+    .toLowerCase()
+    .replace(/https?:\/\/\S+/g, '')
+    .replace(/[^\p{L}\p{N}\s']/gu, ' ')
+    .split(/\s+/)
+    .map((word) => word.replace(/^'+|'+$/g, '').replace(/'/g, ''))
+    .filter((word) => word.length > 1 && !stopWords.has(word));
+}
+
+function extractEmojis(content) {
+  if (!content) return [];
+  const match = content.match(/\p{Extended_Pictographic}/gu);
+  return match ? match : [];
+}
+
+function round(value, digits = 1) {
+  const factor = 10 ** digits;
+  return Math.round(value * factor) / factor;
+}
+
+export function computeStatistics(messages) {
+  if (!messages.length) {
+    return {
+      totalMessages: 0,
+      totalWords: 0,
+      participants: [],
+      messageCountByParticipant: {},
+      wordCountByParticipant: {},
+      mediaCount: 0,
+      systemCount: 0,
+      firstMessageDate: null,
+      lastMessageDate: null,
+      messagesByDate: new Map(),
+      messagesByHour: new Array(24).fill(0),
+      topWords: [],
+      topEmojis: [],
+      averageMessageLength: {},
+      busiestDay: null,
+      busiestHour: null,
+      longestStreak: 0,
+      longestStreakRange: null,
+      responseTimes: {}
+    };
+  }
+
+  const participantsSet = new Set();
+  const messageCountByParticipant = {};
+  const wordCountByParticipant = {};
+  const totalWordsByParticipant = {};
+  const messagesByDate = new Map();
+  const messagesByHour = new Array(24).fill(0);
+  const words = [];
+  const emojiCounts = new Map();
+  const responseTracking = {};
+  const responseTimes = {};
+
+  let totalMessages = 0;
+  let totalWords = 0;
+  let mediaCount = 0;
+  let systemCount = 0;
+
+  const sortedMessages = [...messages].sort((a, b) => a.timestamp - b.timestamp);
+
+  let previousMessage = null;
+
+  for (const message of sortedMessages) {
+    const dateKey = message.timestamp.toISOString().slice(0, 10);
+    messagesByDate.set(dateKey, (messagesByDate.get(dateKey) || 0) + 1);
+    messagesByHour[message.timestamp.getUTCHours()] += 1;
+
+    if (message.type === 'system') {
+      systemCount += 1;
+      previousMessage = message;
+      continue;
+    }
+
+    const author = message.author;
+    participantsSet.add(author);
+    messageCountByParticipant[author] = (messageCountByParticipant[author] || 0) + 1;
+    const wordList = extractWords(message.content);
+    wordCountByParticipant[author] = (wordCountByParticipant[author] || 0) + wordList.length;
+    totalWordsByParticipant[author] = (totalWordsByParticipant[author] || 0) + message.content.length;
+
+    totalMessages += 1;
+    totalWords += wordList.length;
+
+    if (isMediaMessage(message.content)) {
+      mediaCount += 1;
+    } else {
+      words.push(...wordList);
+      const emojis = extractEmojis(message.content);
+      for (const emoji of emojis) {
+        emojiCounts.set(emoji, (emojiCounts.get(emoji) || 0) + 1);
+      }
+    }
+
+    if (previousMessage && previousMessage.type === 'message' && previousMessage.author !== author) {
+      const delta = (message.timestamp - previousMessage.timestamp) / 60000;
+      if (!responseTracking[author]) {
+        responseTracking[author] = [];
+      }
+      responseTracking[author].push(delta);
+    }
+
+    previousMessage = message;
+  }
+
+  const participants = Array.from(participantsSet).sort((a, b) => (messageCountByParticipant[b] || 0) - (messageCountByParticipant[a] || 0));
+
+  for (const [author, deltas] of Object.entries(responseTracking)) {
+    if (deltas.length) {
+      const avg = deltas.reduce((acc, value) => acc + value, 0) / deltas.length;
+      responseTimes[author] = round(avg, 2);
+    }
+  }
+
+  const topWords = Object.entries(words.reduce((acc, word) => {
+    acc[word] = (acc[word] || 0) + 1;
+    return acc;
+  }, {})).sort((a, b) => b[1] - a[1]).slice(0, 15);
+
+  const topEmojis = Array.from(emojiCounts.entries()).sort((a, b) => b[1] - a[1]).slice(0, 10);
+
+  const averageMessageLength = {};
+  for (const participant of participants) {
+    const count = messageCountByParticipant[participant] || 0;
+    averageMessageLength[participant] = count ? round(totalWordsByParticipant[participant] / count, 1) : 0;
+  }
+
+  const [firstMessageDate] = sortedMessages;
+  const lastMessageDate = sortedMessages[sortedMessages.length - 1];
+
+  let busiestDay = null;
+  let busiestDayCount = 0;
+  for (const [date, count] of messagesByDate.entries()) {
+    if (count > busiestDayCount) {
+      busiestDayCount = count;
+      busiestDay = { date, count };
+    }
+  }
+
+  let busiestHour = null;
+  let busiestHourCount = 0;
+  messagesByHour.forEach((count, hour) => {
+    if (count > busiestHourCount) {
+      busiestHourCount = count;
+      busiestHour = hour;
+    }
+  });
+
+  if (busiestHourCount === 0) {
+    busiestHour = null;
+  }
+
+  const streaks = calculateStreaks(messagesByDate);
+
+  return {
+    totalMessages,
+    totalWords,
+    participants,
+    messageCountByParticipant,
+    wordCountByParticipant,
+    mediaCount,
+    systemCount,
+    firstMessageDate: firstMessageDate?.timestamp ?? null,
+    lastMessageDate: lastMessageDate?.timestamp ?? null,
+    messagesByDate,
+    messagesByHour,
+    topWords,
+    topEmojis,
+    averageMessageLength,
+    busiestDay,
+    busiestHour,
+    longestStreak: streaks.length,
+    longestStreakRange: streaks.range,
+    responseTimes
+  };
+}
+
+function calculateStreaks(messagesByDate) {
+  const dates = Array.from(messagesByDate.keys()).sort();
+  if (!dates.length) {
+    return { length: 0, range: null };
+  }
+
+  let bestLength = 1;
+  let currentLength = 1;
+  let bestRange = { start: dates[0], end: dates[0] };
+  let currentStart = dates[0];
+
+  for (let i = 1; i < dates.length; i += 1) {
+    const prev = new Date(dates[i - 1]);
+    const current = new Date(dates[i]);
+    const diff = (current - prev) / 86400000;
+
+    if (diff === 1) {
+      currentLength += 1;
+    } else {
+      if (currentLength > bestLength) {
+        bestLength = currentLength;
+        bestRange = { start: currentStart, end: dates[i - 1] };
+      }
+      currentLength = 1;
+      currentStart = dates[i];
+    }
+  }
+
+  if (currentLength > bestLength) {
+    bestLength = currentLength;
+    bestRange = { start: currentStart, end: dates[dates.length - 1] };
+  }
+
+  return { length: bestLength, range: bestRange };
+}
+
+export function filterMessagesByDate(messages, startDate, endDate) {
+  if (!startDate && !endDate) return [...messages];
+  const start = startDate ? new Date(startDate) : null;
+  const end = endDate ? new Date(endDate) : null;
+
+  return messages.filter((message) => {
+    const ts = message.timestamp;
+    if (start && ts < new Date(start.getTime())) return false;
+    if (end) {
+      const endOfDay = new Date(end.getTime());
+      endOfDay.setUTCHours(23, 59, 59, 999);
+      if (ts > endOfDay) return false;
+    }
+    return true;
+  });
+}
+
+export function generateMarkdownSummary({
+  title = 'WhatsApp Chat Summary',
+  messages,
+  stats,
+  startDate,
+  endDate,
+  sampleCount = 3
+}) {
+  const lines = [];
+  lines.push(`# ${title}`);
+  const dateLine = startDate && endDate
+    ? `**Timeframe:** ${startDate} → ${endDate}`
+    : stats.firstMessageDate && stats.lastMessageDate
+      ? `**Timeframe:** ${stats.firstMessageDate.toISOString().slice(0, 10)} → ${stats.lastMessageDate.toISOString().slice(0, 10)}`
+      : null;
+  if (dateLine) lines.push(dateLine);
+
+  lines.push('');
+  lines.push(`- **Messages analysed:** ${stats.totalMessages.toLocaleString()}`);
+  lines.push(`- **Unique participants:** ${stats.participants.length}`);
+  if (stats.mediaCount) {
+    lines.push(`- **Media shared:** ${stats.mediaCount}`);
+  }
+  if (stats.topWords.length) {
+    lines.push(`- **Top themes:** ${stats.topWords.slice(0, 5).map(([word]) => `\`${word}\``).join(', ')}`);
+  }
+  if (stats.longestStreak > 1 && stats.longestStreakRange) {
+    lines.push(`- **Longest daily streak:** ${stats.longestStreak} days (${stats.longestStreakRange.start} → ${stats.longestStreakRange.end})`);
+  }
+
+  lines.push('\n## Participation');
+  for (const participant of stats.participants) {
+    const count = stats.messageCountByParticipant[participant];
+    const words = stats.wordCountByParticipant[participant];
+    const avgLength = stats.averageMessageLength[participant];
+    const response = stats.responseTimes[participant];
+    const bits = [`${participant}: **${count.toLocaleString()}** messages`];
+    if (words) bits.push(`${words.toLocaleString()} words`);
+    if (avgLength) bits.push(`avg length ${avgLength} chars`);
+    if (response) bits.push(`average response ≈ ${response} min`);
+    lines.push(`- ${bits.join(' · ')}`);
+  }
+
+  if (stats.topWords.length) {
+    lines.push('\n## Frequently used words');
+    const table = ['| Word | Count |', '| --- | ---: |'];
+    for (const [word, count] of stats.topWords.slice(0, 10)) {
+      table.push(`| ${word} | ${count} |`);
+    }
+    lines.push(...table);
+  }
+
+  if (stats.topEmojis.length) {
+    lines.push('\n## Emoji energy');
+    const emojiLine = stats.topEmojis.map(([emoji, count]) => `${emoji} × ${count}`).join(' · ');
+    lines.push(emojiLine);
+  }
+
+  if (sampleCount > 0 && messages.length) {
+    lines.push('\n## Representative moments');
+    const step = Math.max(1, Math.floor(messages.length / sampleCount));
+    for (let i = 0; i < sampleCount && i * step < messages.length; i += 1) {
+      const message = messages[i * step];
+      const date = message.timestamp.toISOString().replace('T', ' ').slice(0, 16);
+      lines.push(`- ${date} · **${message.author}:** ${message.content.replace(/\n/g, ' ')}`);
+    }
+  }
+
+  lines.push('\n---\n_Generated with the WhatsApp Chat Insights Dashboard._');
+
+  return lines.join('\n');
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,114 @@
+{
+  "name": "whatsapp-chat-dashboard",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "whatsapp-chat-dashboard",
+      "version": "1.0.0",
+      "dependencies": {
+        "jszip": "^3.10.1"
+      }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "whatsapp-chat-dashboard",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "node tests/run-tests.js"
+  },
+  "dependencies": {
+    "jszip": "^3.10.1"
+  }
+}

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,299 @@
+:root {
+  color-scheme: light dark;
+  --bg: #0f172a;
+  --card-bg: rgba(15, 23, 42, 0.75);
+  --text: #f8fafc;
+  --muted: #94a3b8;
+  --accent: #38bdf8;
+  --accent-muted: rgba(56, 189, 248, 0.2);
+  --border: rgba(148, 163, 184, 0.2);
+  --success: #34d399;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at top, rgba(56, 189, 248, 0.15), transparent 60%),
+    radial-gradient(circle at 20% 80%, rgba(129, 140, 248, 0.25), transparent 55%),
+    var(--bg);
+  color: var(--text);
+}
+
+.app-header {
+  padding: 3rem 1.5rem 1rem;
+  text-align: center;
+}
+
+.app-header h1 {
+  margin: 0;
+  font-size: clamp(2.2rem, 4vw, 3rem);
+  font-weight: 700;
+}
+
+.app-header p {
+  margin: 0.75rem auto 0;
+  max-width: 640px;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.app-main {
+  display: grid;
+  gap: 1.5rem;
+  padding: 0 1.5rem 3rem;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.card {
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  backdrop-filter: blur(16px);
+  border-radius: 20px;
+  padding: 1.75rem;
+  box-shadow: 0 25px 45px rgba(15, 23, 42, 0.55);
+}
+
+.section-header h2,
+.controls-header h2 {
+  margin: 0;
+  font-size: 1.6rem;
+}
+
+.section-header p,
+.controls-header p {
+  margin: 0.5rem 0 0;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.file-input {
+  margin-top: 1.5rem;
+  border: 2px dashed var(--border);
+  border-radius: 16px;
+  padding: 2rem 1rem;
+  display: block;
+  text-align: center;
+  cursor: pointer;
+  transition: border-color 0.2s ease, background 0.2s ease;
+  color: var(--muted);
+}
+
+.file-input:hover,
+.file-input:focus-within {
+  border-color: var(--accent);
+  background: var(--accent-muted);
+}
+
+.file-input input {
+  display: none;
+}
+
+.file-input span {
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.helper-text {
+  margin-top: 1rem;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.status {
+  margin-top: 1rem;
+  min-height: 1.25rem;
+  color: var(--accent);
+}
+
+.status.error {
+  color: #f87171;
+}
+
+.controls-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  align-items: end;
+  margin-top: 1.25rem;
+}
+
+.controls-grid label span {
+  display: block;
+  color: var(--muted);
+  margin-bottom: 0.5rem;
+}
+
+input[type="date"],
+input[type="text"],
+input[type="number"],
+button,
+textarea {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: rgba(15, 23, 42, 0.4);
+  color: var(--text);
+  font: inherit;
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+input:focus,
+button:focus,
+textarea:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.35);
+}
+
+button {
+  cursor: pointer;
+  font-weight: 600;
+  background: var(--accent);
+  color: #0f172a;
+  border: none;
+}
+
+button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+button.subtle {
+  background: rgba(148, 163, 184, 0.15);
+  color: var(--muted);
+}
+
+.stats-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  margin-top: 1.5rem;
+}
+
+.stat-card {
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 1.25rem;
+  background: rgba(15, 23, 42, 0.55);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.stat-card h3 {
+  margin: 0;
+  font-size: 0.95rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+}
+
+.stat-card p {
+  margin: 0;
+  font-size: 1.6rem;
+  font-weight: 700;
+}
+
+.stat-card span {
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.charts-grid {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  margin-top: 1.5rem;
+}
+
+.chart-block {
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 1rem;
+  background: rgba(15, 23, 42, 0.55);
+}
+
+.chart-block h3 {
+  margin: 0 0 0.75rem;
+  color: var(--muted);
+}
+
+.insights-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  margin-top: 1.5rem;
+}
+
+.pill-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.pill-list li {
+  display: inline-flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(56, 189, 248, 0.18);
+  border: 1px solid rgba(56, 189, 248, 0.35);
+  color: var(--text);
+  font-weight: 500;
+}
+
+.insight-list {
+  list-style: disc;
+  padding-left: 1.25rem;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  color: var(--muted);
+}
+
+.export-controls {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  margin-top: 1.5rem;
+}
+
+#md-preview {
+  margin-top: 1rem;
+  min-height: 220px;
+  resize: vertical;
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  line-height: 1.5;
+}
+
+.app-footer {
+  text-align: center;
+  padding: 2rem 1.5rem 3rem;
+  color: var(--muted);
+}
+
+@media (max-width: 720px) {
+  .card {
+    padding: 1.25rem;
+  }
+
+  .charts-grid,
+  .stats-grid,
+  .insights-grid,
+  .export-controls {
+    grid-template-columns: 1fr;
+  }
+}

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -1,0 +1,57 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import JSZip from 'jszip';
+import { parseChat, computeStatistics, generateMarkdownSummary } from '../js/chatParser.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+async function loadExample() {
+  const zipPath = path.resolve(__dirname, '..', 'Example  WhatsApp Chat - Demosthenes Caldis 1.zip');
+  const buffer = await readFile(zipPath);
+  const zip = await JSZip.loadAsync(buffer);
+  const chatEntry = Object.values(zip.files).find((file) => file.name.endsWith('.txt'));
+  if (!chatEntry) {
+    throw new Error('Example archive does not contain a .txt file');
+  }
+  return chatEntry.async('string');
+}
+
+async function main() {
+  const rawText = await loadExample();
+  const messages = parseChat(rawText);
+  if (!messages.length) {
+    throw new Error('Parser failed to load messages from the example chat.');
+  }
+
+  const stats = computeStatistics(messages);
+  if (stats.participants.length < 2) {
+    throw new Error('Expected at least two participants in the example chat.');
+  }
+
+  if (stats.totalMessages <= 0) {
+    throw new Error('Statistics should report at least one message.');
+  }
+
+  const markdown = generateMarkdownSummary({
+    title: 'Example Chat Recap',
+    messages,
+    stats,
+    sampleCount: 2
+  });
+
+  if (!markdown.includes('# Example Chat Recap')) {
+    throw new Error('Markdown summary did not include the custom title.');
+  }
+
+  console.log('Parsed messages:', messages.length);
+  console.log('Participants detected:', stats.participants.join(', '));
+  console.log('Top word sample:', stats.topWords.slice(0, 3));
+  console.log('Markdown preview snippet:', markdown.split('\n').slice(0, 5).join('\n'));
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add a GitHub Pages friendly dashboard for exploring WhatsApp chat exports with charts, filters, and insights
- implement a robust parser/statistics engine with markdown export support shared between browser and tests
- document usage and add automated regression test against the bundled sample chat

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd178336b08328b5ce0ee668962bdf