### PR TITLE
Fix chart block height

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -218,6 +218,13 @@ button.subtle {
   border-radius: 16px;
   padding: 1rem;
   background: rgba(15, 23, 42, 0.55);
+  height: clamp(280px, 35vw, 360px);
+  position: relative;
+}
+
+.chart-block canvas {
+  width: 100%;
+  height: 100%;
 }
 
 .chart-block h3 {


### PR DESCRIPTION
## Summary
- enforce a consistent height on chart containers and ensure canvases fill the space
- make chart wrappers positioned for responsive Chart.js rendering stability

## Testing
- npm test *(fails: missing fixture `Example  WhatsApp Chat - Demosthenes Caldis 1.zip` in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68dd508ac3888328a1f2a267924dbb53