### PR TITLE
Exclude system messages from activity aggregates

### DIFF
--- a/js/chatParser.js
+++ b/js/chatParser.js
@@ -204,15 +204,15 @@ export function computeStatistics(messages) {
   let previousMessage = null;
 
   for (const message of sortedMessages) {
-    const dateKey = message.timestamp.toISOString().slice(0, 10);
-    messagesByDate.set(dateKey, (messagesByDate.get(dateKey) || 0) + 1);
-    messagesByHour[message.timestamp.getUTCHours()] += 1;
-
     if (message.type === 'system') {
       systemCount += 1;
       previousMessage = message;
       continue;
     }
+
+    const dateKey = message.timestamp.toISOString().slice(0, 10);
+    messagesByDate.set(dateKey, (messagesByDate.get(dateKey) || 0) + 1);
+    messagesByHour[message.timestamp.getUTCHours()] += 1;
 
     const author = message.author;
     participantsSet.add(author);


### PR DESCRIPTION
## Summary
- ensure day and hour message aggregations skip system messages in computeStatistics
- keep busiest day/hour calculations aligned with participant activity only

## Testing
- npm test
- node -e "console.log('See run-tests for validation')"

------
https://chatgpt.com/codex/tasks/task_e_68dd5f445f9483288cf591e829f2751c