### PR TITLE
Add participant reply time insights

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,6 +93,10 @@
           <ol id="top-emojis" class="pill-list"></ol>
         </div>
         <div>
+          <h3>Average reply times</h3>
+          <ul id="response-times" class="response-time-list" aria-live="polite"></ul>
+        </div>
+        <div>
           <h3>Noteworthy observations</h3>
           <ul id="insight-list" class="insight-list"></ul>
         </div>

--- a/js/app.js
+++ b/js/app.js
@@ -23,6 +23,7 @@ const summaryCardsContainer = document.getElementById('summary-cards');
 const topWordsList = document.getElementById('top-words');
 const topEmojisList = document.getElementById('top-emojis');
 const insightList = document.getElementById('insight-list');
+const responseTimesList = document.getElementById('response-times');
 const mdTitleInput = document.getElementById('md-title');
 const sampleCountInput = document.getElementById('sample-count');
 const generateMdButton = document.getElementById('generate-md');
@@ -194,7 +195,55 @@ function updateTopList(container, items, formatter) {
     .join('');
 }
 
+function updateResponseTimesList(currentStats) {
+  if (!responseTimesList) return;
+
+  if (!currentStats.participants.length) {
+    responseTimesList.innerHTML = '<li class="empty">No participants yet</li>';
+    return;
+  }
+
+  const formatter = new Intl.NumberFormat(undefined, {
+    minimumFractionDigits: 1,
+    maximumFractionDigits: 1
+  });
+
+  const entries = currentStats.participants
+    .map((participant, index) => {
+      const value = currentStats.responseTimes?.[participant];
+      return {
+        participant,
+        minutes: typeof value === 'number' ? value : null,
+        order: index
+      };
+    })
+    .sort((a, b) => {
+      if (a.minutes === null && b.minutes === null) {
+        return a.order - b.order;
+      }
+      if (a.minutes === null) return 1;
+      if (b.minutes === null) return -1;
+      if (a.minutes === b.minutes) {
+        return a.participant.localeCompare(b.participant);
+      }
+      return a.minutes - b.minutes;
+    });
+
+  responseTimesList.innerHTML = entries
+    .map(({ participant, minutes }) => {
+      const label = minutes === null ? '—' : `${formatter.format(minutes)} min`;
+      return `
+        <li>
+          <span class="response-name">${participant}</span>
+          <span class="response-time-value">${label}</span>
+        </li>
+      `;
+    })
+    .join('');
+}
+
 function buildInsights(currentStats) {
+  updateResponseTimesList(currentStats);
   const insights = [];
   if (currentStats.busiestDay) {
     insights.push(`Most active day: <strong>${currentStats.busiestDay.date}</strong> with ${currentStats.busiestDay.count} messages.`);

--- a/styles.css
+++ b/styles.css
@@ -264,6 +264,55 @@ button.subtle {
   color: var(--muted);
 }
 
+.response-time-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.response-time-list li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 0.6rem 0.85rem;
+  border-radius: 14px;
+  background: rgba(148, 163, 184, 0.12);
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  color: var(--text);
+  font-weight: 500;
+}
+
+.response-time-list li .response-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.response-time-list li .response-time-value {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  color: var(--muted);
+  white-space: nowrap;
+}
+
+.response-time-list li .response-time-value::before {
+  content: '·';
+  color: var(--muted);
+}
+
+.response-time-list li.empty {
+  justify-content: center;
+  color: var(--muted);
+  font-weight: 400;
+  background: rgba(148, 163, 184, 0.08);
+  border-style: dashed;
+}
+
 .export-controls {
   display: grid;
   gap: 1rem;


### PR DESCRIPTION
## Summary
- add an insights panel list in the dashboard to surface average reply times per participant
- populate the new list by sorting response-time statistics and formatting values in the UI
- style the reply-time list to match existing insight pills

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd5f39e58c8328a134bd3f61113b61