### PR TITLE
Fix chart block sizing

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -218,6 +218,13 @@ button.subtle {
   border-radius: 16px;
   padding: 1rem;
   background: rgba(15, 23, 42, 0.55);
+  height: clamp(280px, 32vw, 360px);
+  position: relative;
+}
+
+.chart-block canvas {
+  width: 100%;
+  height: 100%;
 }
 
 .chart-block h3 {


### PR DESCRIPTION
## Summary
- give chart blocks a clamped height and relative positioning for consistent layout
- let chart canvases fill their containers so Chart.js respects the fixed space

## Testing
- Manual verification: Loaded the dashboard with a sample chat and confirmed both charts keep a steady height

------
https://chatgpt.com/codex/tasks/task_e_68dd5f2eec4483289bc030178ba5eb7a