### PR TITLE
Normalize ZIP entry checks for chat imports

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -35,7 +35,13 @@ async function loadChatFile(file) {
   if (file.name.toLowerCase().endsWith('.zip')) {
     const arrayBuffer = await file.arrayBuffer();
     const zip = await JSZip.loadAsync(arrayBuffer);
-    const txtFileName = Object.keys(zip.files).find((name) => name.endsWith('.txt'));
+    const txtFileName = Object.keys(zip.files).find((name) => {
+      const baseName = name.split('/').pop() || name;
+      if (baseName.startsWith('._')) {
+        return false;
+      }
+      return baseName.toLowerCase().endsWith('.txt');
+    });
     if (!txtFileName) {
       throw new Error('No .txt file found inside the zip archive.');
     }


### PR DESCRIPTION
## Summary
- normalize ZIP entry names before checking for WhatsApp text exports so uppercase extensions load correctly
- ignore macOS resource fork files while scanning ZIP contents to avoid selecting metadata entries

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd61f3c3a083288d4dbe7c49ed29b5