### PR TITLE
Fix status clearing order when loading chat file

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -340,8 +340,8 @@ fileInput.addEventListener('change', async (event) => {
   if (!file) return;
 
   fileHelper.textContent = file.name;
-  loadStatus.textContent = 'Parsing chat…';
   clearStatus();
+  loadStatus.textContent = 'Parsing chat…';
 
   try {
     const rawText = await loadChatFile(file);


### PR DESCRIPTION
## Summary
- ensure the load status is cleared before setting the "Parsing chat…" message so the text remains visible during processing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd61f93da083288c46e0a39220f8cd