### PR TITLE
Ignore media placeholders in word statistics

### DIFF
--- a/js/chatParser.js
+++ b/js/chatParser.js
@@ -217,16 +217,23 @@ export function computeStatistics(messages) {
     const author = message.author;
     participantsSet.add(author);
     messageCountByParticipant[author] = (messageCountByParticipant[author] || 0) + 1;
-    const wordList = extractWords(message.content);
-    wordCountByParticipant[author] = (wordCountByParticipant[author] || 0) + wordList.length;
-    totalWordsByParticipant[author] = (totalWordsByParticipant[author] || 0) + message.content.length;
+
+    if (!(author in wordCountByParticipant)) {
+      wordCountByParticipant[author] = 0;
+    }
+    if (!(author in totalWordsByParticipant)) {
+      totalWordsByParticipant[author] = 0;
+    }
 
     totalMessages += 1;
-    totalWords += wordList.length;
 
     if (isMediaMessage(message.content)) {
       mediaCount += 1;
     } else {
+      const wordList = extractWords(message.content);
+      wordCountByParticipant[author] += wordList.length;
+      totalWordsByParticipant[author] += message.content.length;
+      totalWords += wordList.length;
       words.push(...wordList);
       const emojis = extractEmojis(message.content);
       for (const emoji of emojis) {

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -34,6 +34,26 @@ async function main() {
     throw new Error('Expected at least two participants in the example chat.');
   }
 
+  const mediaPlaceholderMessage = {
+    timestamp: new Date(messages[0].timestamp.getTime() + 60000),
+    author: messages[0].author,
+    content: '<Media omitted>',
+    type: 'message'
+  };
+  const statsWithMedia = computeStatistics([...messages, mediaPlaceholderMessage]);
+
+  if (statsWithMedia.totalWords !== stats.totalWords) {
+    throw new Error('Media placeholder messages should not change the total word count.');
+  }
+
+  for (const participant of stats.participants) {
+    const before = stats.wordCountByParticipant[participant] || 0;
+    const after = statsWithMedia.wordCountByParticipant[participant] || 0;
+    if (before !== after) {
+      throw new Error(`Media placeholder messages should not change the word count for ${participant}.`);
+    }
+  }
+
   const expectedParticipants = ['~Ieommq', 'Imbl'];
   for (const participant of expectedParticipants) {
     if (!stats.participants.includes(participant)) {


### PR DESCRIPTION
## Summary
- skip word and character accumulation for media placeholder messages when computing statistics
- initialise participant word counters so media-only senders are tracked without inflating totals
- extend the run-tests script with a media placeholder scenario to ensure totals remain unchanged

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd623916d083289b899e8ea8fc138b