### PR TITLE
Handle ambiguous WhatsApp date formats with heuristics and UI override

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -11,10 +11,13 @@ let stats = null;
 let fullStats = null;
 let participantsChart = null;
 let hourlyChart = null;
+let activeDateFormat = 'DMY';
+let rawChatText = '';
 
 const fileInput = document.getElementById('chat-file');
 const fileHelper = document.getElementById('file-helper');
 const loadStatus = document.getElementById('load-status');
+const dateFormatChooser = document.createElement('div');
 const startDateInput = document.getElementById('start-date');
 const endDateInput = document.getElementById('end-date');
 const applyRangeButton = document.getElementById('apply-range');
@@ -28,6 +31,11 @@ const mdTitleInput = document.getElementById('md-title');
 const sampleCountInput = document.getElementById('sample-count');
 const generateMdButton = document.getElementById('generate-md');
 const mdPreview = document.getElementById('md-preview');
+
+dateFormatChooser.id = 'date-format-chooser';
+dateFormatChooser.className = 'date-format-chooser';
+dateFormatChooser.hidden = true;
+loadStatus.insertAdjacentElement('afterend', dateFormatChooser);
 
 async function loadChatFile(file) {
   if (!file) return null;
@@ -57,6 +65,50 @@ function formatDateFriendly(date) {
     month: 'short',
     day: 'numeric'
   }).format(date);
+}
+
+function describeDateFormat(format) {
+  return format === 'MDY' ? 'month/day/year' : 'day/month/year';
+}
+
+function hideDateFormatChooser() {
+  dateFormatChooser.hidden = true;
+  dateFormatChooser.innerHTML = '';
+}
+
+function renderDateFormatChooser(parseResult) {
+  if (!parseResult || !parseResult.ambiguous) {
+    hideDateFormatChooser();
+    return;
+  }
+
+  dateFormatChooser.hidden = false;
+  dateFormatChooser.innerHTML = '';
+
+  const info = document.createElement('p');
+  const currentDescription = describeDateFormat(parseResult.dateFormat);
+  info.innerHTML = `Dates could be interpreted multiple ways. Showing as <strong>${currentDescription}</strong>.`;
+  dateFormatChooser.appendChild(info);
+
+  const buttonGroup = document.createElement('div');
+  buttonGroup.className = 'date-format-choices';
+
+  ['DMY', 'MDY'].forEach((format) => {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.textContent = format === 'MDY' ? 'Use month/day/year' : 'Use day/month/year';
+    button.disabled = format === parseResult.dateFormat;
+    button.addEventListener('click', () => applyDateFormatOverride(format));
+    buttonGroup.appendChild(button);
+  });
+
+  dateFormatChooser.appendChild(buttonGroup);
+}
+
+function updateLoadSuccessMessage() {
+  if (!stats) return;
+  const description = describeDateFormat(activeDateFormat);
+  loadStatus.textContent = `Loaded ${stats.totalMessages.toLocaleString()} messages from ${stats.participants.length} participants (dates interpreted as ${description}).`;
 }
 
 function updateSummaryCards(currentStats) {
@@ -300,14 +352,76 @@ function resetFilters() {
   buildInsights(stats);
 }
 
+function processParsedChat(parseResult, options = {}) {
+  const { messages, dateFormat } = parseResult;
+  const { preserveFilters = false } = options;
+
+  if (!messages.length) {
+    throw new Error('No messages could be parsed. Please ensure this is a standard WhatsApp export.');
+  }
+
+  allMessages = messages;
+  filteredMessages = [...messages];
+  activeDateFormat = dateFormat;
+  fullStats = computeStatistics(messages);
+  stats = fullStats;
+
+  const firstDate = formatDateForInput(fullStats.firstMessageDate);
+  const lastDate = formatDateForInput(fullStats.lastMessageDate);
+
+  const clampDate = (value, min, max) => {
+    if (!value) return min;
+    if (value < min) return min;
+    if (value > max) return max;
+    return value;
+  };
+
+  startDateInput.min = firstDate;
+  startDateInput.max = lastDate;
+  endDateInput.min = firstDate;
+  endDateInput.max = lastDate;
+
+  if (preserveFilters) {
+    startDateInput.value = clampDate(startDateInput.value, firstDate, lastDate);
+    endDateInput.value = clampDate(endDateInput.value, firstDate, lastDate);
+    if (endDateInput.value < startDateInput.value) {
+      endDateInput.value = startDateInput.value;
+    }
+  } else {
+    startDateInput.value = firstDate;
+    endDateInput.value = lastDate;
+  }
+
+  enableControls(true);
+  applyFilters();
+
+  renderDateFormatChooser(parseResult);
+  loadStatus.classList.remove('error');
+  updateLoadSuccessMessage();
+}
+
+function applyDateFormatOverride(format) {
+  if (!rawChatText || format === activeDateFormat) return;
+
+  try {
+    const parseResult = parseChat(rawChatText, { dateFormat: format });
+    processParsedChat(parseResult, { preserveFilters: true });
+  } catch (error) {
+    console.error(error);
+    showError(error.message || 'Unable to apply the selected date format.');
+  }
+}
+
 function showError(message) {
   loadStatus.textContent = message;
   loadStatus.classList.add('error');
+  hideDateFormatChooser();
 }
 
 function clearStatus() {
   loadStatus.textContent = '';
   loadStatus.classList.remove('error');
+  hideDateFormatChooser();
 }
 
 function prepareMarkdown() {
@@ -340,35 +454,13 @@ fileInput.addEventListener('change', async (event) => {
   if (!file) return;
 
   fileHelper.textContent = file.name;
-  loadStatus.textContent = 'Parsing chat…';
   clearStatus();
+  loadStatus.textContent = 'Parsing chat…';
 
   try {
-    const rawText = await loadChatFile(file);
-    allMessages = parseChat(rawText);
-
-    if (!allMessages.length) {
-      throw new Error('No messages could be parsed. Please ensure this is a standard WhatsApp export.');
-    }
-
-    fullStats = computeStatistics(allMessages);
-    stats = fullStats;
-    filteredMessages = [...allMessages];
-
-    const firstDate = formatDateForInput(fullStats.firstMessageDate);
-    const lastDate = formatDateForInput(fullStats.lastMessageDate);
-
-    startDateInput.value = firstDate;
-    startDateInput.min = firstDate;
-    startDateInput.max = lastDate;
-    endDateInput.value = lastDate;
-    endDateInput.min = firstDate;
-    endDateInput.max = lastDate;
-
-    enableControls(true);
-    applyFilters();
-
-    loadStatus.textContent = `Loaded ${stats.totalMessages.toLocaleString()} messages from ${stats.participants.length} participants.`;
+    rawChatText = await loadChatFile(file);
+    const parseResult = parseChat(rawChatText);
+    processParsedChat(parseResult);
   } catch (error) {
     console.error(error);
     showError(error.message || 'Something went wrong while parsing the chat.');

--- a/styles.css
+++ b/styles.css
@@ -115,6 +115,31 @@ body {
   color: #f87171;
 }
 
+.date-format-chooser {
+  margin-top: 0.75rem;
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: rgba(15, 23, 42, 0.35);
+}
+
+.date-format-chooser p {
+  margin: 0 0 0.5rem;
+  color: var(--muted);
+}
+
+.date-format-choices {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.date-format-choices button {
+  width: auto;
+  min-width: 0;
+  padding: 0.5rem 0.75rem;
+}
+
 .controls-grid {
   display: grid;
   gap: 1rem;

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -20,7 +20,8 @@ async function loadExample() {
 
 async function main() {
   const rawText = await loadExample();
-  const messages = parseChat(rawText);
+  const parseResult = parseChat(rawText);
+  const { messages } = parseResult;
   if (!messages.length) {
     throw new Error('Parser failed to load messages from the example chat.');
   }
@@ -62,6 +63,58 @@ async function main() {
 
   if (!markdown.includes('**Timeframe:** 2025-07-31 → 2025-07-31')) {
     throw new Error('Markdown summary should include the detected timeframe of the new sample chat.');
+  }
+
+  const ambiguousChat = [
+    '02/03/2024, 09:15 - Alice: Planning session',
+    '03/03/2024, 10:05 - Bob: Following up',
+    '04/03/2024, 11:20 - Alice: Notes shared',
+    '05/03/2024, 12:45 - Bob: Looks good',
+    '06/03/2024, 13:00 - Alice: Ready for launch',
+    '07/03/2024, 14:10 - Bob: Countdown continues',
+    '08/03/2024, 15:25 - Alice: Final checks',
+    '09/03/2024, 16:40 - Bob: Almost done',
+    '10/03/2024, 17:55 - Alice: Deploying now',
+    '11/03/2024, 18:30 - Bob: Deployment succeeded',
+    '12/03/2024, 19:15 - Alice: Retrospective tomorrow'
+  ].join('\n');
+
+  const ambiguousResult = parseChat(ambiguousChat);
+  if (!ambiguousResult.ambiguous) {
+    throw new Error('Expected ambiguous chat detection for the custom sample.');
+  }
+
+  if (ambiguousResult.dateFormat !== 'DMY') {
+    throw new Error('Ambiguous sample should default to day/month/year interpretation.');
+  }
+
+  if (!ambiguousResult.messages.length) {
+    throw new Error('Ambiguous sample should still yield parsed messages.');
+  }
+
+  const firstAmbiguousMonth = ambiguousResult.messages[0].timestamp.getUTCMonth();
+  if (firstAmbiguousMonth !== 2) {
+    throw new Error('DMY interpretation should treat 02/03 as March 2nd (month index 2).');
+  }
+
+  const alternativeResult = parseChat(ambiguousChat, { dateFormat: 'MDY' });
+  if (!alternativeResult.usedOverride) {
+    throw new Error('Override flag should be set when forcing a date format.');
+  }
+
+  const alternativeMonth = alternativeResult.messages[0].timestamp.getUTCMonth();
+  if (alternativeMonth !== 1) {
+    throw new Error('MDY interpretation should treat 02/03 as February 3rd (month index 1).');
+  }
+
+  const dmySpan = ambiguousResult.messages.at(-1).timestamp.getTime() - ambiguousResult.messages[0].timestamp.getTime();
+  const mdySpan = alternativeResult.messages.at(-1).timestamp.getTime() - alternativeResult.messages[0].timestamp.getTime();
+  if (dmySpan <= 0 || mdySpan <= 0) {
+    throw new Error('Span calculations should yield positive values for both interpretations.');
+  }
+
+  if (dmySpan >= mdySpan) {
+    throw new Error('DMY interpretation should result in a smaller overall timespan than MDY for the ambiguous sample.');
   }
 
   console.log('Parsed messages:', messages.length);


### PR DESCRIPTION
## Summary
- enhance the chat parser to evaluate ambiguous WhatsApp date formats, expose the selected format, and support caller overrides
- surface a date format chooser in the dashboard when ambiguity is detected and style the control for clarity
- add regression coverage that asserts ambiguous transcripts default to the most plausible interpretation and accept manual overrides

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd624d39e48328aa0e3b7ce3f13217