### PR TITLE
Add Markdown transcript export for filtered chat ranges

### DIFF
--- a/index.html
+++ b/index.html
@@ -118,8 +118,22 @@
           <input type="number" id="sample-count" min="0" max="10" value="3" />
         </label>
         <button id="generate-md" disabled>Download Markdown</button>
+        <label>
+          <span>Transcript title</span>
+          <input type="text" id="transcript-title" placeholder="e.g. Sprint Retro – Chat Transcript" />
+        </label>
+        <button id="download-transcript" disabled>Download chat transcript</button>
       </div>
-      <textarea id="md-preview" aria-label="Markdown preview" readonly placeholder="Markdown summary will appear here after generation."></textarea>
+      <div class="export-previews">
+        <div>
+          <h3 class="export-preview-heading">Summary preview</h3>
+          <textarea id="md-preview" aria-label="Markdown summary preview" readonly placeholder="Markdown summary will appear here after generation."></textarea>
+        </div>
+        <div>
+          <h3 class="export-preview-heading">Transcript preview</h3>
+          <textarea id="transcript-preview" aria-label="Markdown transcript preview" readonly placeholder="Transcript markdown will appear here after generation."></textarea>
+        </div>
+      </div>
     </section>
   </main>
 

--- a/js/chatParser.js
+++ b/js/chatParser.js
@@ -474,3 +474,48 @@ export function generateMarkdownSummary({
 
   return lines.join('\n');
 }
+
+export function generateMarkdownTranscript({
+  title = 'WhatsApp Chat Transcript',
+  messages = [],
+  startDate,
+  endDate
+}) {
+  const lines = [];
+  lines.push(`# ${title}`);
+
+  let timeframeStart = startDate;
+  let timeframeEnd = endDate;
+
+  if ((!timeframeStart || !timeframeEnd) && messages.length) {
+    timeframeStart = timeframeStart || formatLocalDateKey(messages[0].timestamp);
+    timeframeEnd = timeframeEnd || formatLocalDateKey(messages[messages.length - 1].timestamp);
+  }
+
+  if (timeframeStart && timeframeEnd) {
+    lines.push(`**Timeframe:** ${timeframeStart} → ${timeframeEnd}`);
+  }
+
+  if (!messages.length) {
+    lines.push('', '_No messages available for the selected range._');
+    lines.push('\n---\n_Generated with the WhatsApp Chat Insights Dashboard._');
+    return lines.join('\n');
+  }
+
+  lines.push('\n## Messages');
+
+  for (const message of messages) {
+    const date = formatLocalDateTime(message.timestamp);
+    const cleanContent = message.content.replace(/\s+/g, ' ').trim();
+    if (message.type === 'system') {
+      lines.push(`- ${date} · _${cleanContent || 'System message'}_`);
+    } else {
+      const body = cleanContent || '_No text provided_';
+      lines.push(`- ${date} · **${message.author}:** ${body}`);
+    }
+  }
+
+  lines.push('\n---\n_Generated with the WhatsApp Chat Insights Dashboard._');
+
+  return lines.join('\n');
+}

--- a/styles.css
+++ b/styles.css
@@ -327,12 +327,26 @@ button.subtle {
   margin-top: 1.5rem;
 }
 
-#md-preview {
-  margin-top: 1rem;
+.export-previews {
+  margin-top: 1.5rem;
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.export-preview-heading {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--muted);
+  margin-bottom: 0.5rem;
+}
+
+.export-previews textarea {
   min-height: 220px;
   resize: vertical;
   font-family: 'JetBrains Mono', 'Fira Code', monospace;
   line-height: 1.5;
+  width: 100%;
 }
 
 .app-footer {
@@ -349,7 +363,8 @@ button.subtle {
   .charts-grid,
   .stats-grid,
   .insights-grid,
-  .export-controls {
+  .export-controls,
+  .export-previews {
     grid-template-columns: 1fr;
   }
 }


### PR DESCRIPTION
## Summary
- add controls for configuring and downloading Markdown chat transcripts alongside the existing summary export
- implement transcript Markdown generation that respects the active date range filter and reuses shared download helpers
- update styling to surface side-by-side previews for the summary and transcript outputs

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68dd65b491288328811e317b9dadc704