### PR TITLE
Add Markdown chat transcript export

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,18 +108,40 @@
         <h2 id="export-title">Export a Markdown recap</h2>
         <p>Generate a polished summary for wikis, retros, or changelog entries.</p>
       </div>
-      <div class="export-controls">
-        <label>
-          <span>Summary title</span>
-          <input type="text" id="md-title" placeholder="e.g. Sprint Retro – Team Chat Highlights" />
-        </label>
-        <label>
-          <span>Include sample messages</span>
-          <input type="number" id="sample-count" min="0" max="10" value="3" />
-        </label>
-        <button id="generate-md" disabled>Download Markdown</button>
+
+      <div class="export-section">
+        <h3>Insight summary</h3>
+        <p>Create a concise overview of the selected timeframe, including top stats and sample messages.</p>
+        <div class="export-controls">
+          <label>
+            <span>Summary title</span>
+            <input type="text" id="md-title" placeholder="e.g. Sprint Retro – Team Chat Highlights" />
+          </label>
+          <label>
+            <span>Include sample messages</span>
+            <input type="number" id="sample-count" min="0" max="10" value="3" />
+          </label>
+          <button id="generate-md" disabled>Download summary Markdown</button>
+        </div>
+        <textarea id="md-preview" aria-label="Markdown preview" readonly placeholder="Markdown summary will appear here after generation."></textarea>
       </div>
-      <textarea id="md-preview" aria-label="Markdown preview" readonly placeholder="Markdown summary will appear here after generation."></textarea>
+
+      <div class="export-section">
+        <h3>Chat transcript for LLMs</h3>
+        <p>Use the active date filters to control the transcript window, then export the messages as Markdown.</p>
+        <div class="export-controls">
+          <label>
+            <span>Transcript title</span>
+            <input type="text" id="transcript-title" placeholder="e.g. Incident review – Chat transcript" />
+          </label>
+          <label class="checkbox-option">
+            <input type="checkbox" id="include-system-messages" />
+            <span>Include system messages (e.g. "You changed the group icon")</span>
+          </label>
+          <button id="download-transcript" disabled>Download transcript Markdown</button>
+        </div>
+        <textarea id="transcript-preview" aria-label="Transcript markdown preview" readonly placeholder="Filtered chat transcript will appear here after export."></textarea>
+      </div>
     </section>
   </main>
 

--- a/js/chatParser.js
+++ b/js/chatParser.js
@@ -474,3 +474,53 @@ export function generateMarkdownSummary({
 
   return lines.join('\n');
 }
+
+export function generateMarkdownTranscript({
+  title = 'WhatsApp Chat Transcript',
+  messages = [],
+  includeSystemMessages = false,
+  startDate,
+  endDate
+}) {
+  const relevantMessages = includeSystemMessages
+    ? [...messages]
+    : messages.filter((message) => message.type !== 'system');
+
+  const lines = [];
+  lines.push(`# ${title}`);
+
+  if (startDate && endDate) {
+    lines.push(`**Timeframe:** ${startDate} → ${endDate}`);
+  } else if (relevantMessages.length) {
+    const ordered = [...relevantMessages].sort((a, b) => a.timestamp - b.timestamp);
+    const first = ordered[0];
+    const last = ordered[ordered.length - 1];
+    lines.push(`**Timeframe:** ${formatLocalDateKey(first.timestamp)} → ${formatLocalDateKey(last.timestamp)}`);
+  }
+
+  lines.push('');
+
+  if (!relevantMessages.length) {
+    lines.push('_No messages available in this period._');
+    lines.push('\n---\n_Generated with the WhatsApp Chat Insights Dashboard._');
+    return lines.join('\n');
+  }
+
+  const label = includeSystemMessages ? 'Total entries' : 'Total participant messages';
+  lines.push(`- **${label}:** ${relevantMessages.length.toLocaleString()}`);
+  lines.push('');
+  lines.push('```');
+
+  for (const message of relevantMessages) {
+    const timestamp = formatLocalDateTime(message.timestamp);
+    const author = message.type === 'system' ? 'System' : message.author;
+    const content = message.content || '';
+    const formatted = content.replace(/```/g, '\u0060\u0060\u0060');
+    lines.push(`[${timestamp}] ${author}: ${formatted}`);
+  }
+
+  lines.push('```');
+  lines.push('\n---\n_Generated with the WhatsApp Chat Insights Dashboard._');
+
+  return lines.join('\n');
+}

--- a/styles.css
+++ b/styles.css
@@ -326,13 +326,61 @@ button.subtle {
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   margin-top: 1.5rem;
 }
+.export-section:first-of-type {
+  margin-top: 1.5rem;
+}
 
-#md-preview {
+.export-section + .export-section {
+  margin-top: 2rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--border);
+}
+
+.export-section h3 {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.export-section p {
+  margin: 0.5rem 0 0;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+#md-preview,
+#transcript-preview {
   margin-top: 1rem;
   min-height: 220px;
   resize: vertical;
   font-family: 'JetBrains Mono', 'Fira Code', monospace;
   line-height: 1.5;
+}
+
+#transcript-preview {
+  min-height: 320px;
+}
+
+.checkbox-option {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.85rem 1rem;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: rgba(15, 23, 42, 0.4);
+  color: var(--muted);
+  line-height: 1.4;
+  grid-column: span 2;
+}
+
+.checkbox-option input {
+  width: 1.1rem;
+  height: 1.1rem;
+  accent-color: var(--accent);
+}
+
+.checkbox-option span {
+  flex: 1;
 }
 
 .app-footer {

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -2,7 +2,7 @@ import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import JSZip from 'jszip';
-import { parseChat, computeStatistics, generateMarkdownSummary } from '../js/chatParser.js';
+import { parseChat, computeStatistics, generateMarkdownSummary, generateMarkdownTranscript } from '../js/chatParser.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -82,6 +82,36 @@ async function main() {
 
   if (!markdown.includes('**Timeframe:** 2025-07-31 → 2025-07-31')) {
     throw new Error('Markdown summary should include the detected timeframe of the new sample chat.');
+  }
+
+  const transcript = generateMarkdownTranscript({
+    title: 'Example Chat Transcript',
+    messages,
+    includeSystemMessages: false
+  });
+
+  if (!transcript.includes('# Example Chat Transcript')) {
+    throw new Error('Transcript export should honour the provided title.');
+  }
+
+  if (!transcript.includes('```')) {
+    throw new Error('Transcript export should include a fenced code block for the conversation.');
+  }
+
+  if (!transcript.includes('[2025-07-31')) {
+    throw new Error('Transcript export should include message timestamps.');
+  }
+
+  const transcriptWithMeta = generateMarkdownTranscript({
+    title: 'Example Chat Transcript',
+    messages,
+    includeSystemMessages: true,
+    startDate: '2025-07-31',
+    endDate: '2025-07-31'
+  });
+
+  if (!transcriptWithMeta.includes('**Timeframe:** 2025-07-31 → 2025-07-31')) {
+    throw new Error('Transcript export should surface the supplied date range.');
   }
 
   console.log('Parsed messages:', messages.length);


### PR DESCRIPTION
## Summary
- add export controls and styling to download the filtered chat as a Markdown transcript alongside the existing summary
- implement transcript generation logic and shared download helper in the app and parser modules
- cover the transcript export flow with automated tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd65b491288328811e317b9dadc704