### PR TITLE
Add reply-gap threshold controls for response time metrics

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,6 +94,27 @@
         </div>
         <div>
           <h3>Average reply times</h3>
+          <div class="response-controls">
+            <label class="response-field">
+              <span>Ignore gaps longer than</span>
+              <div class="response-input-row">
+                <input type="number" id="response-gap-limit" min="0" step="15" placeholder="e.g. 180" disabled />
+                <span class="suffix">min</span>
+              </div>
+            </label>
+            <label class="response-field response-toggle">
+              <input type="checkbox" id="response-overnight-toggle" disabled />
+              <span>Add overnight buffer</span>
+            </label>
+            <label class="response-field">
+              <span>Overnight buffer</span>
+              <div class="response-input-row">
+                <input type="number" id="response-overnight-minutes" min="0" step="30" value="480" disabled />
+                <span class="suffix">min</span>
+              </div>
+            </label>
+          </div>
+          <p class="response-cutoff-note" id="response-cutoff-note">Average reply times will appear once a chat is loaded.</p>
           <ul id="response-times" class="response-time-list" aria-live="polite"></ul>
         </div>
         <div>

--- a/styles.css
+++ b/styles.css
@@ -296,6 +296,54 @@ button.subtle {
   color: var(--muted);
 }
 
+.response-controls {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  margin: 0 0 0.75rem;
+}
+
+.response-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.response-field .response-input-row {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.response-field .response-input-row input[type="number"] {
+  flex: 1 1 auto;
+}
+
+.response-field .suffix {
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.response-field.response-toggle {
+  grid-column: 1 / -1;
+  flex-direction: row;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.response-field.response-toggle input[type="checkbox"] {
+  width: auto;
+  accent-color: var(--accent);
+}
+
+.response-cutoff-note {
+  margin: 0 0 0.75rem;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
 .response-time-list {
   list-style: none;
   padding: 0;


### PR DESCRIPTION
## Summary
- add configurable response-gap thresholding in the statistics engine and expose the active cutoff metadata
- surface reply-gap and overnight buffer controls in the dashboard UI with refreshed styling and guidance
- extend regression coverage to confirm long pauses are ignored once thresholds are enabled

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd7551f57083289e8b2624368235d9