### PR TITLE
Add participant word frequency insights to dashboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,6 +89,14 @@
           <ol id="top-words" class="pill-list"></ol>
         </div>
         <div>
+          <h3>Words by participant</h3>
+          <div class="participant-words-controls">
+            <label for="participant-word-selector">Participant</label>
+            <select id="participant-word-selector" disabled></select>
+          </div>
+          <ol id="participant-top-words" class="pill-list" aria-live="polite"></ol>
+        </div>
+        <div>
           <h3>Top emojis</h3>
           <ol id="top-emojis" class="pill-list"></ol>
         </div>

--- a/styles.css
+++ b/styles.css
@@ -157,6 +157,7 @@ body {
 input[type="date"],
 input[type="text"],
 input[type="number"],
+select,
 button,
 textarea {
   width: 100%;
@@ -170,6 +171,7 @@ textarea {
 }
 
 input:focus,
+select:focus,
 button:focus,
 textarea:focus {
   outline: none;
@@ -262,6 +264,25 @@ button.subtle {
   gap: 1.5rem;
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
   margin-top: 1.5rem;
+}
+
+.participant-words-controls {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  flex-wrap: wrap;
+  margin-bottom: 0.75rem;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.participant-words-controls label {
+  font-weight: 600;
+}
+
+.participant-words-controls select {
+  flex: 1 1 160px;
+  min-width: 160px;
 }
 
 .pill-list {


### PR DESCRIPTION
## Summary
- extend chat statistics to compute per-participant word frequency lists and expose them via topWordsByParticipant
- add insights UI controls for selecting a participant and viewing their most used words with matching styles
- update application rendering logic and regression tests to surface and verify participant-specific word breakdowns

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd995564748328b90cc406f452cd67