### PR TITLE
Add word contribution averages and dashboard visualization

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,6 +72,10 @@
           <canvas id="participants-chart" aria-label="Messages per participant chart" role="img"></canvas>
         </div>
         <div class="chart-block">
+          <h3>Word contributions</h3>
+          <canvas id="words-chart" aria-label="Word totals and averages per participant" role="img"></canvas>
+        </div>
+        <div class="chart-block">
           <h3>Hourly rhythm</h3>
           <canvas id="hourly-chart" aria-label="Messages by hour chart" role="img"></canvas>
         </div>


### PR DESCRIPTION
## Summary
- add participant and overall average words per message to the computed statistics and markdown summary
- surface a new word contributions chart plus summary card in the dashboard UI
- extend regression tests to validate the new averages across media placeholders and filtered ranges

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd99618b2c83288780d0095ee1f485