### PR TITLE
Add participant word frequency insights to dashboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,6 +92,16 @@
           <h3>Top words</h3>
           <ol id="top-words" class="pill-list"></ol>
         </div>
+        <div class="participant-word-breakdown">
+          <h3>Words by participant</h3>
+          <label class="participant-word-label" for="participant-word-select">
+            <span>Select participant</span>
+            <select id="participant-word-select" disabled>
+              <option value="">No participants yet</option>
+            </select>
+          </label>
+          <ol id="participant-top-words" class="pill-list"></ol>
+        </div>
         <div>
           <h3>Top emojis</h3>
           <ol id="top-emojis" class="pill-list"></ol>

--- a/styles.css
+++ b/styles.css
@@ -157,6 +157,7 @@ body {
 input[type="date"],
 input[type="text"],
 input[type="number"],
+select,
 button,
 textarea {
   width: 100%;
@@ -262,6 +263,28 @@ button.subtle {
   gap: 1.5rem;
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
   margin-top: 1.5rem;
+}
+
+.participant-word-breakdown {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.participant-word-label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  color: var(--muted);
+}
+
+.participant-word-label span {
+  font-size: 0.9rem;
+}
+
+.participant-word-label select:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 
 .pill-list {


### PR DESCRIPTION
## Summary
- compute participant-level word frequency maps during statistics generation and expose the top terms
- add UI controls and rendering logic for selecting a participant and viewing their top words
- update styling and regression tests to cover the new per-person word insights

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dda2d8f9e88328b11a29150f4a4c6d