### PR TITLE
Improve participant word selector UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,11 +95,13 @@
         <div class="participant-word-breakdown">
           <h3>Words by participant</h3>
           <label class="participant-word-label" for="participant-word-select">
-            <span>Select participant</span>
-            <select id="participant-word-select" disabled>
+            <span id="participant-word-label">Select participant</span>
+            <select id="participant-word-select" class="visually-hidden" aria-labelledby="participant-word-label" disabled>
               <option value="">No participants yet</option>
             </select>
           </label>
+          <div id="participant-word-selector" class="participant-word-selector" role="radiogroup" aria-labelledby="participant-word-label"></div>
+          <p id="participant-word-summary" class="participant-word-summary" aria-live="polite">No participants yet</p>
           <ol id="participant-top-words" class="pill-list"></ol>
         </div>
         <div>

--- a/styles.css
+++ b/styles.css
@@ -15,6 +15,18 @@
   box-sizing: border-box;
 }
 
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 body {
   margin: 0;
   min-height: 100vh;
@@ -285,6 +297,60 @@ button.subtle {
 .participant-word-label select:disabled {
   opacity: 0.5;
   cursor: not-allowed;
+}
+
+.participant-word-selector {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  align-items: center;
+  padding: 0.25rem 0;
+}
+
+.participant-word-selector:empty::before {
+  content: 'No participants yet';
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.participant-word-pill {
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: rgba(148, 163, 184, 0.12);
+  color: var(--muted);
+  padding: 0.45rem 0.85rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.participant-word-pill[aria-checked="true"] {
+  background: var(--accent);
+  color: #0f172a;
+  border-color: transparent;
+  box-shadow: 0 8px 18px rgba(56, 189, 248, 0.25);
+}
+
+.participant-word-pill:hover,
+.participant-word-pill:focus-visible {
+  border-color: var(--accent);
+  color: var(--text);
+  outline: none;
+  transform: translateY(-1px);
+}
+
+.participant-word-pill:focus-visible {
+  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.25);
+}
+
+.participant-word-pill[aria-checked="true"]:focus-visible {
+  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.45);
+}
+
+.participant-word-summary {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--muted);
 }
 
 .pill-list {


### PR DESCRIPTION
## Summary
- replace the words-by-participant dropdown with chip-based controls and add a live summary for average words per message
- style the new participant selector, including a visually hidden native select fallback for accessibility
- update the dashboard logic to render the selector pills, keep them in sync with statistics, and support keyboard navigation

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ddaaac98ec83288b692d3530f6c3d0