### PR TITLE
Improve median reply time visibility in insights panel

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -634,20 +634,33 @@ function updateResponseTimesList(currentStats) {
       `;
       }
 
-      const segments = [];
+      const metrics = [];
       if (average !== null) {
-        segments.push(`avg ${formatter.format(average)} min`);
+        metrics.push(`
+          <span class="response-metric" data-kind="avg">
+            <span class="metric-label">avg</span>
+            <span class="metric-value">${formatter.format(average)} min</span>
+          </span>
+        `);
       }
       if (median !== null) {
-        segments.push(`median ${formatter.format(median)} min`);
+        metrics.push(`
+          <span class="response-metric" data-kind="median">
+            <span class="metric-label">median</span>
+            <span class="metric-value">${formatter.format(median)} min</span>
+          </span>
+        `);
       }
-      const sampleSuffix = samples > 0 ? ` (${samples} gap${samples === 1 ? '' : 's'})` : '';
-      const label = `${segments.join(' · ')}${sampleSuffix}`;
+
+      const metricsHtml = metrics.map((metric) => metric.trim()).join('');
+      const sampleLabel = samples > 0
+        ? `<span class="response-sample">${samples} gap${samples === 1 ? '' : 's'}</span>`
+        : '';
 
       return `
         <li>
           <span class="response-name">${participant}</span>
-          <span class="response-time-value">${label}</span>
+          <span class="response-time-value">${metricsHtml}${sampleLabel}</span>
         </li>
       `;
     })

--- a/styles.css
+++ b/styles.css
@@ -426,9 +426,9 @@ button.subtle {
 
 .response-time-list li {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
-  gap: 0.5rem;
+  gap: 0.75rem;
   padding: 0.6rem 0.85rem;
   border-radius: 14px;
   background: rgba(148, 163, 184, 0.12);
@@ -444,16 +444,53 @@ button.subtle {
 }
 
 .response-time-list li .response-time-value {
-  display: inline-flex;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
   align-items: center;
-  gap: 0.35rem;
+  gap: 0.45rem;
   color: var(--muted);
-  white-space: nowrap;
+  text-align: right;
 }
 
-.response-time-list li .response-time-value::before {
-  content: '·';
+.response-time-list li .response-time-value .response-metric {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.3rem;
+  padding: 0.2rem 0.55rem;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.18);
+  border: 1px solid rgba(148, 163, 184, 0.32);
+  color: var(--text);
+  font-weight: 600;
+  font-size: 0.85rem;
+  box-shadow: inset 0 1px 1px rgba(255, 255, 255, 0.08);
+}
+
+.response-time-list li .response-time-value .response-metric[data-kind="median"] {
+  background: rgba(96, 165, 250, 0.18);
+  border-color: rgba(96, 165, 250, 0.35);
+}
+
+.response-time-list li .response-time-value .metric-label {
+  text-transform: uppercase;
+  font-size: 0.65rem;
+  letter-spacing: 0.05em;
   color: var(--muted);
+}
+
+.response-time-list li .response-time-value .response-metric[data-kind="median"] .metric-label {
+  color: #7cc4ff;
+}
+
+.response-time-list li .response-time-value .metric-value {
+  font-variant-numeric: tabular-nums;
+}
+
+.response-time-list li .response-time-value .response-sample {
+  font-size: 0.75rem;
+  color: var(--muted);
+  align-self: center;
 }
 
 .response-time-list li.empty {


### PR DESCRIPTION
## Summary
- render reply time averages and medians as dedicated badges so both metrics remain visible
- tweak reply time list layout and styling to accommodate wrapped metrics and highlight median values

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ddab28426c8328a64427c766471dc9