### PR TITLE
Adjust message length stats to use trimmed character counts

### DIFF
--- a/js/chatParser.js
+++ b/js/chatParser.js
@@ -322,7 +322,7 @@ export function computeStatistics(messages, options = {}) {
   const participantsSet = new Set();
   const messageCountByParticipant = {};
   const wordCountByParticipant = {};
-  const totalWordsByParticipant = {};
+  const totalCharsByParticipant = {};
   const wordFrequencyByParticipant = {};
   const longestMessageByParticipant = {};
   const messagesByDate = new Map();
@@ -359,8 +359,8 @@ export function computeStatistics(messages, options = {}) {
     if (!(author in wordCountByParticipant)) {
       wordCountByParticipant[author] = 0;
     }
-    if (!(author in totalWordsByParticipant)) {
-      totalWordsByParticipant[author] = 0;
+    if (!(author in totalCharsByParticipant)) {
+      totalCharsByParticipant[author] = 0;
     }
     if (!(author in wordFrequencyByParticipant)) {
       wordFrequencyByParticipant[author] = {};
@@ -384,7 +384,7 @@ export function computeStatistics(messages, options = {}) {
     } else {
       wordList = extractWords(content);
       wordCountByParticipant[author] += wordList.length;
-      totalWordsByParticipant[author] += content.length;
+      totalCharsByParticipant[author] += charCount;
       totalWords += wordList.length;
       words.push(...wordList);
       const frequency = wordFrequencyByParticipant[author];
@@ -460,7 +460,7 @@ export function computeStatistics(messages, options = {}) {
   const averageWordsPerMessage = {};
   for (const participant of participants) {
     const count = messageCountByParticipant[participant] || 0;
-    averageMessageLength[participant] = count ? round(totalWordsByParticipant[participant] / count, 1) : 0;
+    averageMessageLength[participant] = count ? round(totalCharsByParticipant[participant] / count, 1) : 0;
     const words = wordCountByParticipant[participant] || 0;
     averageWordsPerMessage[participant] = count ? round(words / count, 1) : 0;
   }

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -207,6 +207,27 @@ async function main() {
   ensureAveragesMatchCounts(stats);
   ensureAveragesMatchCounts(statsWithMedia);
 
+  const whitespaceMessages = [
+    { timestamp: new Date(2024, 0, 1, 9, 0), author: 'Trimmer', content: 'Hello   ', type: 'message' },
+    { timestamp: new Date(2024, 0, 1, 9, 1), author: 'Trimmer', content: '  spaced out   ', type: 'message' },
+    { timestamp: new Date(2024, 0, 1, 9, 2), author: 'Trimmer', content: 'Line with newline\n\n', type: 'message' }
+  ];
+
+  const whitespaceStats = computeStatistics(whitespaceMessages);
+  const trimmedTotal = whitespaceMessages.reduce((sum, message) => sum + (message.content || '').trim().length, 0);
+  const rawTotal = whitespaceMessages.reduce((sum, message) => sum + (message.content || '').length, 0);
+  const expectedTrimmedAverage = roundToTenth(trimmedTotal / whitespaceMessages.length);
+  const expectedRawAverage = roundToTenth(rawTotal / whitespaceMessages.length);
+
+  if (expectedTrimmedAverage === expectedRawAverage) {
+    throw new Error('Whitespace fixture should produce different trimmed and raw averages.');
+  }
+
+  const reportedAverageLength = whitespaceStats.averageMessageLength.Trimmer;
+  if (reportedAverageLength !== expectedTrimmedAverage) {
+    throw new Error(`Average message length should ignore surrounding whitespace. Expected ${expectedTrimmedAverage}, got ${reportedAverageLength}.`);
+  }
+
   for (const participant of stats.participants) {
     const before = stats.wordCountByParticipant[participant] || 0;
     const after = statsWithMedia.wordCountByParticipant[participant] || 0;


### PR DESCRIPTION
## Summary
- track per-participant trimmed character totals when computing average message lengths
- add regression coverage to ensure averages ignore trailing whitespace and newlines

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de7f83fac48328aefbfd94f321904f