### PR TITLE
Add participant distinctive vocabulary insights

### DIFF
--- a/index.html
+++ b/index.html
@@ -102,7 +102,16 @@
           </label>
           <div id="participant-word-selector" class="participant-word-selector" role="radiogroup" aria-labelledby="participant-word-label"></div>
           <p id="participant-word-summary" class="participant-word-summary" aria-live="polite">No participants yet</p>
-          <ol id="participant-top-words" class="pill-list"></ol>
+          <div class="participant-word-columns">
+            <div>
+              <h4 class="participant-word-subtitle">Most used</h4>
+              <ol id="participant-top-words" class="pill-list"></ol>
+            </div>
+            <div>
+              <h4 class="participant-word-subtitle">Most distinctive</h4>
+              <ol id="participant-distinctive-words" class="pill-list"></ol>
+            </div>
+          </div>
         </div>
         <div>
           <h3>Top emojis</h3>

--- a/styles.css
+++ b/styles.css
@@ -283,6 +283,21 @@ button.subtle {
   gap: 0.75rem;
 }
 
+.participant-word-columns {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.participant-word-subtitle {
+  margin: 0 0 0.25rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
 .participant-word-label {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- compute distinctive vocabulary per participant and expose it to the dashboard and markdown export
- show a new "Most distinctive" list in the participant word breakdown with supporting UI updates and insights copy
- refresh styles so the participant vocabulary section accommodates the new highlights

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de7d2ea42c8328ad94d2eec6f9532a